### PR TITLE
Add splash screen with polished intro

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,19 @@
+/* Splash screen styles */
+#splash-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #0d1117;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  transition: opacity 0.5s ease-out;
+}
+
+#splash-screen.hidden {
+  opacity: 0;
+  pointer-events: none;
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
 </head>
 <body class="bg-[#0d1117] text-gray-200 font-sans leading-relaxed">
 
+  <div id="splash-screen" class="fixed inset-0 flex items-center justify-center bg-[#0d1117] z-50">
+    <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-green-400 drop-shadow-lg">Benjamín Rebolledo</h1>
+  </div>
+
   <!-- PORTADA -->
   <section class="page h-screen flex flex-col items-center justify-center text-center px-6">
     <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-green-400 drop-shadow-lg">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var splash = document.getElementById('splash-screen');
+  if (!splash) return;
+  setTimeout(function () {
+    splash.classList.add('hidden');
+    splash.addEventListener('transitionend', function () {
+      splash.remove();
+    });
+    var title = document.querySelector('h1');
+    if (title) {
+      title.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, 2000);
+});


### PR DESCRIPTION
## Summary
- show a splash screen overlay when the page loads
- fade out the overlay after two seconds and scroll to the title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850ddc5f654832aac1db2823d0b24bd