### PR TITLE
Ensure sections adapt height on laptops

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
       scroll-snap-type: y mandatory;
     }
     main#fullpage {
-      overflow: hidden;   /* desktop */
+      overflow-y: auto;   /* desktop */
     }
   }
 
@@ -212,7 +212,7 @@
   }
   main#fullpage {
     scroll-behavior: smooth;
-    overflow: hidden;   /* desktop */
+    overflow-y: auto;   /* desktop */
   }
   /* … */
   @media (max-width: 1023px) {
@@ -222,12 +222,6 @@
   }
   #fullpage > section {
     min-height: 100vh;
-  }
-
-  @media (min-width: 1024px) {
-    #fullpage > section {
-      height: 100vh;
-    }
   }
   #scroll-hint {
     bottom: 2rem;
@@ -252,7 +246,7 @@
   <main
     id="fullpage"
     class="
-      h-screen                     /* igual altura que el viewport */
+      min-h-screen                /* igual altura que el viewport */
       overflow-y-auto              /* permite scroll siempre */
       overscroll-contain           /* evita rebote en extremos */
       scroll-behavior-smooth       /* scroll suave */
@@ -263,7 +257,7 @@
     <!-- PORTADA -->
     <section
       id="intro-content"
-      class="page h-screen lg:scroll-snap-align-start lg:scroll-snap-stop-always
+      class="page min-h-screen lg:scroll-snap-align-start lg:scroll-snap-stop-always
          flex flex-col items-center justify-center text-center px-6
          opacity-0 scale-95 transition-all duration-700"
     >
@@ -296,7 +290,7 @@
       id="sobre-mi"
       class="
         page
-        lg:h-screen
+        lg:min-h-screen
         lg:scroll-snap-align-start
         max-w-3xl mx-auto py-12 px-8
         lg:flex lg:flex-col lg:justify-center lg:items-center
@@ -342,7 +336,7 @@
       id="proyecto-destacado"
       class="
         page
-        lg:h-screen
+        lg:min-h-screen
         lg:scroll-snap-align-start
         max-w-5xl mx-auto py-12 px-8
         lg:flex lg:flex-col lg:justify-center lg:items-center
@@ -376,7 +370,7 @@
       id="motivacion"
       class="
         page
-        lg:h-screen
+        lg:min-h-screen
         lg:scroll-snap-align-start
         max-w-4xl mx-auto py-16 px-8
         lg:flex lg:flex-col lg:justify-center lg:items-center


### PR DESCRIPTION
## Summary
- use `min-h-screen` on main container and sections
- remove redundant CSS rule

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685668dceb18832aa630557701686468